### PR TITLE
Added SchemesMasterURL and TemplatesMasterURL to config.yaml_sample

### DIFF
--- a/config.yaml_sample
+++ b/config.yaml_sample
@@ -1,6 +1,10 @@
 ---
 # Get a toke at https://github.com/settings/tokens/new improve rate limit
 GithubToken: ""
+# Set the URL for the Schemes master list
+SchemesMasterURL: "https://raw.githubusercontent.com/chriskempson/base16-schemes-source/master/list.yaml"
+# Set the URL for the Templates master list
+TemplatesMasterURL: "https://raw.githubusercontent.com/chriskempson/base16-templates-source/master/list.yaml"
 # Select a colorscheme you want to use
 Colorscheme: "flat.yaml"
 # Location where the avaitible colorschemes will be cached


### PR DESCRIPTION
When https://github.com/binaryplease/base16-universal-manager/commit/b17dcfadd3861515ad06f40b1bc3529117146360 was merged, these values were moved to the `config.yaml`, but the template wasn't updated accordingly. 

Fixed the following error when these values are missing from the config:
```
No templates in list, pulling new one...
panic: Get ?access_token=: unsupported protocol scheme ""
```