### PR TITLE
Respect applications' "enabled" property when rendering templates

### DIFF
--- a/config.go
+++ b/config.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"fmt"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"os"
+
+	"gopkg.in/yaml.v2"
 )
 
 type SetterConfig struct {
@@ -48,12 +49,12 @@ func (c SetterConfig) Show() {
 	fmt.Println("TemplatesCachePath: ", c.TemplatesCachePath)
 	fmt.Println("DryRun: ", c.DryRun)
 
-	for k, v := range c.Applications {
-		fmt.Println("  App: ", k)
-		fmt.Println("    Enabled: ", v.Enabled)
-		fmt.Println("    Hook: ", v.Hook)
-		for k1, v1 := range v.Files {
-			fmt.Println("      ", k1, "  ", v1)
+	for app, appConfig := range c.Applications {
+		fmt.Println("  App: ", app)
+		fmt.Println("    Enabled: ", appConfig.Enabled)
+		fmt.Println("    Hook: ", appConfig.Hook)
+		for k, v := range appConfig.Files {
+			fmt.Println("      ", k, "  ", v)
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/hoisie/mustache"
-	"gopkg.in/alecthomas/kingpin.v2"
 	"os"
 	"path/filepath"
+
+	"github.com/hoisie/mustache"
+	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 // Configuration file
@@ -51,15 +52,16 @@ func main() {
 	scheme := schemeList.Find(appConf.Colorscheme)
 	fmt.Println("[CONFIG]: Selected scheme: ", scheme.Name)
 
-	for k := range appConf.Applications {
+	templateEnabled := false
+	for app, appConfig := range appConf.Applications {
+		if appConfig.Enabled {
+			Base16Render(templateList.Find(app), scheme)
+			templateEnabled = true
+		}
+	}
 
-		schemeList = LoadBase16ColorschemeList()
-		templateList = LoadBase16TemplateList()
-
-		templ := templateList.Find(k)
-
-		Base16Render(templ, scheme)
-
+	if !templateEnabled {
+		fmt.Println("No templates enabled")
 	}
 
 }


### PR DESCRIPTION
The `enabled` property for each application was not being consulted when
iterating through the list of application themes to be rendered.

Fixes #24 