### PR TITLE
Use default values for scheme and template list URLs

### DIFF
--- a/config.go
+++ b/config.go
@@ -9,6 +9,9 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+var defaultSchemesMasterURL = "https://raw.githubusercontent.com/chriskempson/base16-schemes-source/master/list.yaml"
+var defaultTemplatesMasterURL = "https://raw.githubusercontent.com/chriskempson/base16-templates-source/master/list.yaml"
+
 // SetterConfig is the applicaton's configuration.
 type SetterConfig struct {
 	GithubToken        string                     `yaml:"GithubToken"`
@@ -47,6 +50,13 @@ func NewConfig(path string) SetterConfig {
 	check(err)
 	err = yaml.Unmarshal((file), &conf)
 	check(err)
+
+	if conf.SchemesMasterURL == "" {
+		conf.SchemesMasterURL = defaultSchemesMasterURL
+	}
+	if conf.TemplatesMasterURL == "" {
+		conf.TemplatesMasterURL = defaultTemplatesMasterURL
+	}
 
 	conf.SchemesCachePath = filepath.Join(xdgDirs.CacheHome(), "schemes")
 	conf.SchemesListFile = filepath.Join(xdgDirs.CacheHome(), "schemeslist.yaml")

--- a/config.yaml_sample
+++ b/config.yaml_sample
@@ -1,12 +1,12 @@
 ---
 # Get a token at https://github.com/settings/tokens/new to improve rate limit
 GithubToken: ""
-# Set the URL for the Schemes master list
-SchemesMasterURL: "https://raw.githubusercontent.com/chriskempson/base16-schemes-source/master/list.yaml"
-# Set the URL for the Templates master list
-TemplatesMasterURL: "https://raw.githubusercontent.com/chriskempson/base16-templates-source/master/list.yaml"
 # Select a colorscheme you want to use
 Colorscheme: "flat.yaml"
+
+# Scheme and template list URLs default to the following but can be overridden if you wish
+#SchemesMasterURL: "https://raw.githubusercontent.com/chriskempson/base16-schemes-source/master/list.yaml"
+#TemplatesMasterURL: "https://raw.githubusercontent.com/chriskempson/base16-templates-source/master/list.yaml"
 
 # Enable/Disable dry-run. If enabled no configs will be altered
 DryRun: true

--- a/config_test.go
+++ b/config_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 )
@@ -60,5 +62,25 @@ func TestSetterConfig_Show(t *testing.T) {
 			}
 			c.Show()
 		})
+	}
+}
+
+func TestDefaultMasterURLs(t *testing.T) {
+	// Create a temporary, empty config file
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "base16-universal-manager-")
+	if err != nil {
+		t.Fatalf("Cannot create temporary file\n")
+	}
+	if err := tmpFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	config := NewConfig(tmpFile.Name())
+	if config.SchemesMasterURL == "" {
+		t.Fatalf("SchemesMasterURL should default to %s\n", defaultSchemesMasterURL)
+	}
+	if config.TemplatesMasterURL == "" {
+		t.Fatalf("TemplatesMasterURL should default to %s\n", defaultTemplatesMasterURL)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ var appConf SetterConfig
 
 func main() {
 	//Parse Flags
-	kingpin.Version("0.2.0")
+	kingpin.Version("0.2.1")
 	kingpin.Parse()
 
 	appConf = NewConfig(*configFileFlag)


### PR DESCRIPTION
Rather than require the explicit inclusion of SchemesMasterURL and
TemplatesMasterURL in the configuration, default to the usual values if
not present.

Closes #30